### PR TITLE
Switch to mysql2 gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sudo RACK_ENV=production ruby server.rb
 - xml-simple for XML parsing: https://github.com/maik/xml-simple
 - htmlentities for HTML escaping: https://github.com/threedaymonk/htmlentities
 - rubyzip for zipping source archives: https://github.com/rubyzip/rubyzip
-- mysql for MySQL database queries: https://rubygems.org/gems/mysql
+- mysql2 for MySQL database queries: https://rubygems.org/gems/mysql2
 
 ###### Other libraries used
 

--- a/server.rb
+++ b/server.rb
@@ -17,7 +17,7 @@
 # xml-simple for XML parsing: https://github.com/maik/xml-simple
 # htmlentities for HTML escaping: https://github.com/threedaymonk/htmlentities
 # rubyzip for zipping source archives: https://github.com/rubyzip/rubyzip
-# mysql for MySQL database queries: https://rubygems.org/gems/mysql
+# mysql2 for MySQL database queries: https://rubygems.org/gems/mysql2
 #
 # Other libraries used:
 #

--- a/tests/comment_tests.rb
+++ b/tests/comment_tests.rb
@@ -287,7 +287,7 @@ class CommentTests < Test::Unit::TestCase
       return_statement = connection.query("SELECT * FROM `" + project_name +"`")
       new_id = 1
       new_depth = 0
-      return_statement.each_hash do |row|
+      return_statement.each do |row|
         comment_id = row['Comment_ID'].to_i
         if comment_id >= new_id
           new_id = comment_id + 1
@@ -300,7 +300,7 @@ class CommentTests < Test::Unit::TestCase
       # Use prepared statement to prevent SQL injection
       connection.query("INSERT INTO `Portfolio`.`" + project_name +"` (`Date`, `Name`, `Comment`, `Comment_ID`, `Parent_ID`, `Depth`) VALUES ('2014-10-28','" + author + "', '" + comment+ "', '" + new_id.to_s+ "', '" + parent_id.to_s+ "', '" + new_depth.to_s + "');")
 
-     rescue Mysql::Error => e
+     rescue Mysql2::Error => e
         error_msg = e.to_s
 
 


### PR DESCRIPTION
## Summary
- use `mysql2` gem instead of the deprecated `mysql`
- update Comments class to work with `mysql2`
- adjust tests for the new gem
- update documentation and comments

## Testing
- `ruby tests/comment_tests.rb` *(fails: cannot load such file -- mysql2)*
- `ruby tests/parser_tests.rb` *(fails: cannot load such file -- xmlsimple)*

------
https://chatgpt.com/codex/tasks/task_b_6845825bfb1c8323add7c0c84e8764f2